### PR TITLE
allow autoform 3.1.0+

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ Package.on_use(function(api){
     'accounts-password',
     'underscore',
     'aldeed:collection2@2.1.0',
-    'aldeed:autoform@2.0.2',
+    'aldeed:autoform@2.0.2 | 3.1.0',
     'alanning:roles@1.2.13',
     'raix:handlebar-helpers@0.1.2'
     ],


### PR DESCRIPTION
Doing it this way will break your package on pre Meteor 0.9.3 I think since the pipe separator wasn't added until 0.9.3. You could instead change it to only `aldeed:autoform@3.1.0` if you want to keep supporting Meteor 0.9.2.
