### PR TITLE
Added option to specify itemTemplate in config

### DIFF
--- a/lib/client/html/admin_templates.html
+++ b/lib/client/html/admin_templates.html
@@ -156,27 +156,27 @@
 </template>
 
 <template name="adminPagesItem">
-	{{#if admin_is_users_collection}}
-		{{> adminPagesUserItem}}
-	{{else}}
-	<tr>
-		{{#each admin_table_columns}}
-			{{#if template}}
-			<td>{{> Template.dynamic template=template data=value}}</td>
-			{{else}}
-			<td>{{{admin_table_value this ../_id}}}</td>
-			{{/if}}
-		{{/each}}
-		<td>
-			<a href="{{pathFor 'adminDashboardEdit' _id=_id collection=admin_collection_name}}" class="hidden-xs btn btn-xs btn-primary"><i class="fa fa-pencil"></i></a>
-			<a href="{{pathFor 'adminDashboardEdit' _id=_id collection=admin_collection_name}}" class="visible-xs btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Edit</a>
-		</td>
-		<td>
-			<a data-toggle="modal" doc="{{_id}}" href='#admin-delete-modal' class="hidden-xs btn btn-xs btn-danger btn-delete"><i class="fa fa-times" doc="{{_id}}"></i></a>
-			<a data-toggle="modal" doc="{{_id}}" href='#admin-delete-modal' class="visible-xs btn btn-sm btn-danger btn-delete"><i class="fa fa-times" doc="{{_id}}"></i> Delete</a>
-		</td>
-	</tr>
-	{{/if}}
+	{{> Template.dynamic template=adminItemTemplate data=this}}
+</template>
+
+<template name="adminPagesDefaultItem">
+<tr>
+	{{#each admin_table_columns}}
+		{{#if template}}
+		<td>{{> Template.dynamic template=template data=value}}</td>
+		{{else}}
+		<td>{{{admin_table_value this ../_id}}}</td>
+		{{/if}}
+	{{/each}}
+	<td>
+		<a href="{{pathFor 'adminDashboardEdit' _id=_id collection=admin_collection_name}}" class="hidden-xs btn btn-xs btn-primary"><i class="fa fa-pencil"></i></a>
+		<a href="{{pathFor 'adminDashboardEdit' _id=_id collection=admin_collection_name}}" class="visible-xs btn btn-sm btn-primary"><i class="fa fa-pencil"></i> Edit</a>
+	</td>
+	<td>
+		<a data-toggle="modal" doc="{{_id}}" href='#admin-delete-modal' class="hidden-xs btn btn-xs btn-danger btn-delete"><i class="fa fa-times" doc="{{_id}}"></i></a>
+		<a data-toggle="modal" doc="{{_id}}" href='#admin-delete-modal' class="visible-xs btn btn-sm btn-danger btn-delete"><i class="fa fa-times" doc="{{_id}}"></i> Delete</a>
+	</td>
+</tr>
 </template>
 
 <template name="adminPagesUserItem">

--- a/lib/client/js/helpers.coffee
+++ b/lib/client/js/helpers.coffee
@@ -131,6 +131,16 @@ UI.registerHelper 'adminTemplate', (collection,mode)->
 	if collection.toLowerCase() != 'users' && typeof AdminConfig.collections[collection].templates != 'undefined'
 		AdminConfig.collections[collection].templates[mode]
 
+UI.registerHelper 'adminItemTemplate', ->
+	tpl = 'adminPagesDefaultItem'
+	collection = Session.get 'admin_collection_name'
+	if collection.toLowerCase() == 'users'
+		tpl = 'adminPagesUserItem'
+	else if typeof AdminConfig.collections[collection].itemTemplate != 'undefined'
+		tpl = AdminConfig.collections[collection].itemTemplate
+
+	tpl
+
 UI.registerHelper 'adminGetCollection', (collection)->
 	AdminConfig.collections[collection]
 


### PR DESCRIPTION
I added the option to specify a whole custom itemTemplate, which is needed sometimes when the field config does not suffice.

Can be specified like this: 

``` javascript
AdminConfig.collections.Locations = {
  tableColumns: [
    {label: 'Title', name: 'title'},
    {label: 'Status', name: 'getPrettyStatus'}
  ],
  itemTemplate: 'adminLocationItem'
};
```
