### PR TITLE
Fixed passing document to custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The admin dashboard is heavily customisable. Most of the possibilities are repre
               edit:
                 name: 'postWYSIGEditor'
                 data:
-                  post: Session.get 'admin_doc' if Meteor.isClient
+                  post: ()-> Session.get 'admin_doc' if Meteor.isClient
         },
         Comments: {
             icon: 'comment'


### PR DESCRIPTION
Because the document to be edited ('admin_doc') isn't available in the Session when the AdminConfig is executed, I think this should be delayed by wrapping it a function.