### PR TITLE
Define defaultColumns

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -20,6 +20,11 @@ adminEditDelButtons = [
 	}
 ]
 
+defaultColumns = [
+  data: '_id',
+  title: 'ID'
+]
+
 AdminTables.Users = new Tabular.Table
 	name: 'Users'
 	collection: Meteor.users


### PR DESCRIPTION
Fixes the fact that `defaultColumns` is referenced but never defined