### PR TITLE
Allow custimazation of schema used for Meteor.users collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,31 @@ Comments: {
 
 `color` styles the widget. See the [LTE Admin documentation](http://almsaeedstudio.com/preview/).
 
+#### Users ####
+
+The Meteor.users collection is automatically added to the admin panel.
+You can create, view and delete users.
+
+If you have attached a schema to the user, it will automatically be used for the edit form.
+You can disable this functionality, or customize the schema that is used.
+
+```javascript
+@AdminConfig = 
+    ...
+    // Disable editing of user fields:
+    userSchema: null,
+
+    // Use a custom SimpleSchema:
+    userSchema: new SimpleSchema({
+      'profile.gender': {
+        type: String,
+        allowedValues: ['male', 'female']
+      }
+    }),
+
+```
+
+
 #### Custom Templates ####
 The default admin templates are autoForm instances based on the schemas assigned to the collections. If they don't do the job, you specify a custom template to use for each of the `new`,`edit` and `view` screens for each collection.
 ```

--- a/lib/client/html/admin_templates.html
+++ b/lib/client/html/admin_templates.html
@@ -75,8 +75,8 @@
 
 <template name="AdminDashboardUsersEdit">
 	{{> adminAlert}}
-	{{#if adminUserSchemaExists}}
-	{{> quickForm id="adminUpdateUser" buttonContent="Update" buttonClasses="btn btn-primary btn-sm" collection=adminGetUsers doc=admin_current_doc omitFields="roles,services"}}
+	{{#if adminGetUserSchema}}
+	{{> quickForm id="adminUpdateUser" buttonContent="Update" buttonClasses="btn btn-primary btn-sm" collection=adminGetUsers schema=adminGetUserSchema doc=admin_current_doc omitFields="roles,services"}}
 	<hr/>
 	{{/if}}
 	

--- a/lib/client/js/helpers.coffee
+++ b/lib/client/js/helpers.coffee
@@ -65,8 +65,13 @@ UI.registerHelper 'adminIsUserInRole', (_id,role)->
 UI.registerHelper 'adminGetUsers', ->
 	Meteor.users
 
-UI.registerHelper 'adminUserSchemaExists', ->
-	typeof Meteor.users._c2 == 'object'
+UI.registerHelper 'adminGetUserSchema', ->
+	if _.has(AdminConfig, 'userSchema')
+		schema = AdminConfig.userSchema
+	else if typeof Meteor.users._c2 == 'object'
+		schema = Meteor.users.simpleSchema()
+
+	return schema
 
 UI.registerHelper 'adminCollectionLabel', (collection)->
 	AdminDashboard.collectionLabel(collection) if collection?


### PR DESCRIPTION
This PR adds a new setting in AdminConfig that allows to customize the SimpleSchema used for the user collection.

If the option is not supplied, the behaviour is the same as it is now: if a schema is attached to the user, it will be used, otherwise nothing is shown.

```javascript
AdminConfig = {
  userSchema: new SImpleSchema({})
}
```