### PR TITLE
Add options to hide the edit and del columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Comments: {
               {label: 'Post', name: 'postTitle()'}
               {label: 'User', name: 'owner', template: 'userEmail'}
             ]
+            
+            showEditColumn: true // Set to false to hide the edit button. True by default. 
+            showDelColumn: true // Set to false to hide the edit button. True by default. 
             showWidget: false
             color: 'red'
         }

--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -1,23 +1,27 @@
 @AdminTables = {}
 
 adminTablesDom = '<"box"<"box-header"<"box-toolbar"<"pull-left"<lf>><"pull-right"p>>><"box-body"t>>'
+
+adminEditButton = {
+	data: '_id'
+	title: 'Edit'
+	createdCell: (node, cellData, rowData) ->
+		$(node).html(Blaze.toHTMLWithData Template.adminEditBtn, {_id: cellData}, node)
+	width: '40px'
+	orderable: false
+}
+adminDelButton = {
+	data: '_id'
+	title: 'Delete'
+	createdCell: (node, cellData, rowData) ->
+		$(node).html(Blaze.toHTMLWithData Template.adminDeleteBtn, {_id: cellData}, node)
+	width: '40px'
+	orderable: false
+}
+
 adminEditDelButtons = [
-	{
-		data: '_id'
-		title: 'Edit'
-		createdCell: (node, cellData, rowData) ->
-			$(node).html(Blaze.toHTMLWithData Template.adminEditBtn, {_id: cellData}, node)
-		width: '40px'
-		orderable: false
-	}
-	{
-		data: '_id'
-		title: 'Delete'
-		createdCell: (node, cellData, rowData) ->
-			$(node).html(Blaze.toHTMLWithData Template.adminDeleteBtn, {_id: cellData}, node)
-		width: '40px'
-		orderable: false
-	}
+	adminEditButton,
+	adminDelButton
 ]
 
 defaultColumns = [
@@ -60,6 +64,11 @@ adminTablePubName = (collection) ->
 
 adminCreateTables = (collections) ->
 	_.each AdminConfig?.collections, (collection, name) ->
+		_.defaults collection, {
+			showEditColumn: true
+			showDelColumn: true
+		}
+
 		columns = _.map collection.tableColumns, (column) ->
 			if column.template
 				createdCell = (node, cellData, rowData) ->
@@ -72,12 +81,17 @@ adminCreateTables = (collections) ->
 		if columns.length == 0
 			columns = defaultColumns
 
+		if collection.showEditColumn
+			columns.push(adminEditButton)
+		if collection.showDelColumn
+			columns.push(adminDelButton)
+
 		AdminTables[name] = new Tabular.Table
 			name: name
 			collection: adminCollectionObject(name)
 			pub: collection.children and adminTablePubName(name)
 			sub: collection.sub
-			columns: _.union columns, adminEditDelButtons
+			columns: columns
 			extraFields: collection.extraFields
 			dom: adminTablesDom
 


### PR DESCRIPTION
Adds two options to hide the edit and delete columns in a table.

Example:

```javascript
AdminConfig.collections.Locations = {
  showEditColumn: false,
  showDelColumn: false,

  tableColumns: [
    {label: 'Nr', name: 'locationId'},
  ],
};
```

Also added example in README