### PR TITLE
Render cell templates directly to the node to allow template events

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -63,7 +63,7 @@ adminCreateTables = (collections) ->
 		columns = _.map collection.tableColumns, (column) ->
 			if column.template
 				createdCell = (node, cellData, rowData) ->
-					$(node).html(Blaze.toHTMLWithData Template[column.template], {value: cellData, doc: rowData}, node)
+					Blaze.renderWithData(Template[column.template], {value: cellData, doc: rowData}, node)
 
 			data: column.name
 			title: column.label


### PR DESCRIPTION
Right now, cell templates are renderd directly to html with Blaze.renderToHtml.

This prevents me from creating intearctive columns that have events attached.

This PR replaces the Blaze.renderToHtml to Blaze.renderWithData, which places the rendered content into the given node and attaches the event handlers for the template.


