### PR TITLE
a fix for auth services which do not provide an email

### DIFF
--- a/lib/server/methods.coffee
+++ b/lib/server/methods.coffee
@@ -37,7 +37,7 @@ Meteor.methods
 				user.email = email
 				unless doc.chooseOwnPassword
 					user.password = doc.password
-					
+
 				_id = Accounts.createUser user
 
 				if doc.sendPassword && typeof AdminConfig.fromEmail != 'undefined'
@@ -72,8 +72,9 @@ Meteor.methods
 
 	adminCheckAdmin: ->
 		check arguments, [Match.Any]
-		if this.userId and !Roles.userIsInRole this.userId, ['admin']
-			email = Meteor.users.findOne(_id:this.userId).emails[0].address
+		user = Meteor.users.findOne(_id:this.userId)
+		if this.userId and !Roles.userIsInRole(this.userId, ['admin']) and (user.emails.length > 0)
+			email = user.emails[0].address
 			if typeof Meteor.settings.adminEmails != 'undefined'
 				adminEmails = Meteor.settings.adminEmails
 				if adminEmails.indexOf(email) > -1


### PR DESCRIPTION
Whilst integrating with stripe's oauth system, (https://atmospherejs.com/dancaws/accounts-stripe) I found that it does not establish an email for the user record. The `adminCheckAdmin` function naively checks this array and since it does not exist, it throws an exception and refuses to allow any user in the admin dashboard.

This PR adds a simple check to prevent this.

This was tested against a regular non-admin user, an admin user with access to the dashboard and a user authenticated via Stripe.