### PR TITLE
Optional Bootstrap and FontAwesome lazyloading

### DIFF
--- a/lib/both/router.coffee
+++ b/lib/both/router.coffee
@@ -1,3 +1,7 @@
+if Meteor.isClient
+	Session.set 'admin_bootstrap_loaded', false
+	Session.set 'admin_fontawesome_loaded', false
+
 @AdminController = RouteController.extend
 	layoutTemplate: 'AdminLayout'
 	waitOn: ->
@@ -21,6 +25,22 @@
 			Meteor.call 'adminCheckAdmin'
 			if typeof AdminConfig?.nonAdminRedirectRoute == 'string'
 				Router.go AdminConfig.nonAdminRedirectRoute
+		
+		if AdminConfig.lazyLoad?.bootstrap and not Session.get('admin_bootstrap_loaded')
+			$("<link/>", {
+				rel: "stylesheet"
+				type: "text/css"
+				href: "//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"
+			}).appendTo('head')
+			Session.set 'admin_bootstrap_loaded', true
+		
+		if AdminConfig.lazyLoad?.fontawesome and not Session.get('admin_fontawesome_loaded')
+			$("<link/>", {
+				rel: "stylesheet"
+				type: "text/css"
+				href: "//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"
+			}).appendTo('head')
+			Session.set 'admin_fontawesome_loaded', true
 		
 		@next()
 


### PR DESCRIPTION
This makes Bootstrap and FontAwesome lazyloading possible, for if you don't want to use both/either of those to be used in the entire project, but just in the Admin interface.

Usage:

``` coffeescript
@AdminConfig =
  # ...
  lazyLoad: {
    bootstrap: true
    fontawesome: true
  }
```
