### PR TITLE
Revert "added Roles.GLOBAL_GROUP"

### DIFF
--- a/lib/server/methods.coffee
+++ b/lib/server/methods.coffee
@@ -81,12 +81,12 @@ Meteor.methods
 				adminEmails = Meteor.settings.adminEmails
 				if adminEmails.indexOf(email) > -1
 					console.log 'Adding admin user: ' + email
-					Roles.addUsersToRoles this.userId, ['admin'], Roles.GLOBAL_GROUP
+					Roles.addUsersToRoles this.userId, ['admin']
 			else if typeof AdminConfig != 'undefined' and typeof AdminConfig.adminEmails == 'object'
 				adminEmails = AdminConfig.adminEmails
 				if adminEmails.indexOf(email) > -1
 					console.log 'Adding admin user: ' + email
-					Roles.addUsersToRoles this.userId, ['admin'], Roles.GLOBAL_GROUP
+					Roles.addUsersToRoles this.userId, ['admin']
 			else if this.userId == Meteor.users.findOne({},{sort:{createdAt:1}})._id
 				console.log 'Making first user admin: ' + email
 				Roles.addUsersToRoles this.userId, ['admin']
@@ -94,7 +94,7 @@ Meteor.methods
 	adminAddUserToRole: (_id,role)->
 		check arguments, [Match.Any]
 		if Roles.userIsInRole this.userId, ['admin']
-			Roles.addUsersToRoles _id, role, Roles.GLOBAL_GROUP
+			Roles.addUsersToRoles _id, role
 
 	adminRemoveUserToRole: (_id,role)->
 		check arguments, [Match.Any]


### PR DESCRIPTION
Reverts yogiben/meteor-admin#163

The changes in the above pull request break the role toggles in the user detail page. Adding the role works, but removing it is broken. Fixing it _could_ just require calling the `Roles.removeUsersFromRoles` method with `Roles.GLOBAL_GROUP` as third parameter:

``` coffee
adminRemoveUserToRole: (_id,role)->
    check arguments, [Match.Any]
    if Roles.userIsInRole this.userId, ['admin']
        Roles.removeUsersFromRoles _id, role, Roles.GLOBAL_GROUP
```

Although I suggest reconsidering specifying the group in the first place. When a group is specified calling `alanning:roles`'s methods,the following structure is used for the user `roles` property:

``` json
{
    "roles": {
        "group_one": ["role_one"]
    }
}
```

while if we don't specify a group the structure used is:

``` json
{
    "roles": ["role_one"]
}
```

Since the default (and most used?) behaviour of `alanning:roles` is the second one, I would suggest defaulting to that, with a configuration option which allows to switch to the other behaviour.

I didn't really understand the reason behind yogiben/meteor-admin#163, but I would think the proposed changes wouldn't affect the desired outcome (provided the correct configuration is applied).
