### PR TITLE
Added adminRole property and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ AdminConfig = {
   }
 };
 ```
+
+By default, the `"admin"` role will be used to identify administrators. To identify administrators by another role, you can use the `adminRole` property:
+
+```javascript
+AdminConfig = {
+  name: 'My App',
+  adminRole: 'Owner',
+  collections: {
+    Posts: {}
+  }
+};
+```
+
 #### 3. Define your data models ####
 If you are unfamiliar with [autoform](https://github.com/aldeed/meteor-autoform) or [collection2](https://github.com/aldeed/meteor-collection2) or [collection-helpers](https://github.com/dburles/meteor-collection-helpers) you should check them out now.
 

--- a/lib/both/AdminDashboard.coffee
+++ b/lib/both/AdminDashboard.coffee
@@ -8,7 +8,7 @@ AdminDashboard =
 		Session.set 'adminError', message
 
 	checkAdmin: ->
-		if not Roles.userIsInRole Meteor.userId(), ['admin']
+		if not Roles.userIsInRole Meteor.userId(), [AdminConfig?.adminRole or 'admin']
 			Meteor.call 'adminCheckAdmin'
 			if (typeof AdminConfig?.nonAdminRedirectRoute == "string")
 			  Router.go AdminConfig.nonAdminRedirectRoute

--- a/lib/both/router.coffee
+++ b/lib/both/router.coffee
@@ -17,7 +17,7 @@
 		Session.set 'admin_id', null
 		Session.set 'admin_doc', null
 
-		if not Roles.userIsInRole Meteor.userId(), ['admin']
+		if not Roles.userIsInRole Meteor.userId(), [AdminConfig?.adminRole or 'admin']
 			Meteor.call 'adminCheckAdmin'
 			if typeof AdminConfig?.nonAdminRedirectRoute == 'string'
 				Router.go AdminConfig.nonAdminRedirectRoute

--- a/lib/client/html/admin_layouts.html
+++ b/lib/client/html/admin_layouts.html
@@ -1,6 +1,6 @@
 <template name="AdminLayout">
   {{#if AdminConfig}}
-  {{#if isInRole 'admin'}}
+  {{#if isInRole adminRole}}
     <div class="admin-layout">
     {{#AdminLTE}}
   			{{> AdminHeader}}

--- a/lib/client/html/admin_templates.html
+++ b/lib/client/html/admin_templates.html
@@ -148,7 +148,7 @@
 </template>
 
 <template name="adminUsersIsAdmin">
-	{{#if adminIsUserInRole this._id 'admin'}}<i class="fa fa-check"></i>{{/if}}
+	{{#if adminIsUserInRole this._id adminRole}}<i class="fa fa-check"></i>{{/if}}
 </template>
 
 <template name="adminUsersMailBtn">

--- a/lib/client/js/helpers.coffee
+++ b/lib/client/js/helpers.coffee
@@ -21,6 +21,9 @@ adminCollections = ->
 UI.registerHelper 'AdminConfig', ->
 	AdminConfig if typeof AdminConfig != 'undefined'
 
+UI.registerHelper 'adminRole', ->
+  AdminConfig?.adminRole or 'admin'
+
 UI.registerHelper 'admin_skin', ->
 	AdminConfig?.skin or 'blue'
 

--- a/lib/server/methods.coffee
+++ b/lib/server/methods.coffee
@@ -1,7 +1,7 @@
 Meteor.methods
 	adminInsertDoc: (doc,collection)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			Future = Npm.require('fibers/future');
 			fut = new Future();
 
@@ -11,7 +11,7 @@ Meteor.methods
 
 	adminUpdateDoc: (modifier,collection,_id)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			Future = Npm.require('fibers/future');
 			fut = new Future();
 			adminCollectionObject(collection).update {_id:_id},modifier,(e,r)->
@@ -20,7 +20,7 @@ Meteor.methods
 
 	adminRemoveDoc: (collection,_id)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			if collection == 'Users'
 				Meteor.users.remove {_id:_id}
 			else
@@ -30,7 +30,7 @@ Meteor.methods
 
 	adminNewUser: (doc) ->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			emails = doc.email.split(',')
 			_.each emails, (email)->
 				user = {}
@@ -52,7 +52,7 @@ Meteor.methods
 
 	adminUpdateUser: (modifier,_id)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			Future = Npm.require('fibers/future');
 			fut = new Future();
 			Meteor.users.update {_id:_id},modifier,(e,r)->
@@ -61,13 +61,13 @@ Meteor.methods
 
 	adminSendResetPasswordEmail: (doc)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			console.log 'Changing password for user ' + doc._id
 			Accounts.sendResetPasswordEmail(doc._id)
 
 	adminChangePassword: (doc)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			console.log 'Changing password for user ' + doc._id
 			Accounts.setPassword(doc._id, doc.password)
 			label: 'Email user their new password'
@@ -75,30 +75,30 @@ Meteor.methods
 	adminCheckAdmin: ->
 		check arguments, [Match.Any]
 		user = Meteor.users.findOne(_id:this.userId)
-		if this.userId and !Roles.userIsInRole(this.userId, ['admin']) and (user.emails.length > 0)
+		if this.userId and !Roles.userIsInRole(this.userId, [AdminConfig?.adminRole or 'admin']) and (user.emails.length > 0)
 			email = user.emails[0].address
 			if typeof Meteor.settings.adminEmails != 'undefined'
 				adminEmails = Meteor.settings.adminEmails
 				if adminEmails.indexOf(email) > -1
 					console.log 'Adding admin user: ' + email
-					Roles.addUsersToRoles this.userId, ['admin'], Roles.GLOBAL_GROUP
+					Roles.addUsersToRoles this.userId, [AdminConfig?.adminRole or 'admin'], Roles.GLOBAL_GROUP
 			else if typeof AdminConfig != 'undefined' and typeof AdminConfig.adminEmails == 'object'
 				adminEmails = AdminConfig.adminEmails
 				if adminEmails.indexOf(email) > -1
 					console.log 'Adding admin user: ' + email
-					Roles.addUsersToRoles this.userId, ['admin'], Roles.GLOBAL_GROUP
+					Roles.addUsersToRoles this.userId, [AdminConfig?.adminRole or 'admin'], Roles.GLOBAL_GROUP
 			else if this.userId == Meteor.users.findOne({},{sort:{createdAt:1}})._id
 				console.log 'Making first user admin: ' + email
-				Roles.addUsersToRoles this.userId, ['admin']
+				Roles.addUsersToRoles this.userId, [AdminConfig?.adminRole or 'admin']
 
 	adminAddUserToRole: (_id,role)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			Roles.addUsersToRoles _id, role, Roles.GLOBAL_GROUP
 
 	adminRemoveUserToRole: (_id,role)->
 		check arguments, [Match.Any]
-		if Roles.userIsInRole this.userId, ['admin']
+		if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 			Roles.removeUsersFromRoles _id, role
 
 	adminSetCollectionSort: (collection, _sort) ->

--- a/lib/server/publish.coffee
+++ b/lib/server/publish.coffee
@@ -1,7 +1,7 @@
 Meteor.publishComposite 'adminCollectionDoc', (collection, id) ->
 	check collection, String
 	check id, Match.OneOf(String, Mongo.ObjectID)
-	if Roles.userIsInRole this.userId, ['admin']
+	if Roles.userIsInRole this.userId, [AdminConfig?.adminRole or 'admin']
 		find: ->
 			adminCollectionObject(collection).find(id)
 		children: AdminConfig?.collections?[collection]?.children or []
@@ -9,7 +9,7 @@ Meteor.publishComposite 'adminCollectionDoc', (collection, id) ->
 		@ready()
 
 Meteor.publish 'adminUsers', ->
-	if Roles.userIsInRole @userId, ['admin']
+	if Roles.userIsInRole @userId, [AdminConfig?.adminRole or 'admin']
 		Meteor.users.find()
 	else
 		@ready()


### PR DESCRIPTION
When being used as a drop-in admin panel, sometimes the existing system isn't using the normal `admin` role to identify administrators. In my case, `Admin` was being used, but it's feasible that other roles could be used as well.

This PR adds a `adminRole` option to the `AdminConfig`. If it is set, that string is used as the "admin role" in the system. If it's not set, it defaults to `admin`.

I updated the docs as well.