### PR TITLE
conditionally create the Users table if it hasn't already been defined

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -29,47 +29,6 @@ defaultColumns = () -> [
   title: 'ID'
 ]
 
-AdminTables.Users = new Tabular.Table
-	# Modify selector to allow search by email
-	changeSelector: (selector, userId) ->
-		$or = selector['$or']
-		$or and selector['$or'] = _.map $or, (exp) ->
-			if exp.emails?['$regex']?
-				emails: $elemMatch: address: exp.emails
-			else
-				exp
-		selector
-
-	name: 'Users'
-	collection: Meteor.users
-	columns: _.union [
-		{
-			data: '_id'
-			title: 'Admin'
-			# TODO: use `tmpl`
-			createdCell: (node, cellData, rowData) ->
-				$(node).html(Blaze.toHTMLWithData Template.adminUsersIsAdmin, {_id: cellData}, node)
-			width: '40px'
-		}
-		{
-			data: 'emails'
-			title: 'Email'
-			render: (value) ->
-				value[0].address
-			searchable: true
-		}
-		{
-			data: 'emails'
-			title: 'Mail'
-			# TODO: use `tmpl`
-			createdCell: (node, cellData, rowData) ->
-				$(node).html(Blaze.toHTMLWithData Template.adminUsersMailBtn, {emails: cellData}, node)
-			width: '40px'
-		}
-		{ data: 'createdAt', title: 'Joined' }
-	], adminEditDelButtons
-	dom: adminTablesDom
-
 adminTablePubName = (collection) ->
 	"admin_tabular_#{collection}"
 
@@ -185,3 +144,46 @@ Meteor.startup ->
 	adminCreateTables AdminConfig?.collections
 	adminCreateRoutes AdminConfig?.collections
 	adminPublishTables AdminConfig?.collections if Meteor.isServer
+	
+	if AdminTables.Users then return undefined
+	
+	AdminTables.Users = new Tabular.Table
+		# Modify selector to allow search by email
+		changeSelector: (selector, userId) ->
+			$or = selector['$or']
+			$or and selector['$or'] = _.map $or, (exp) ->
+				if exp.emails?['$regex']?
+					emails: $elemMatch: address: exp.emails
+				else
+					exp
+			selector
+	
+		name: 'Users'
+		collection: Meteor.users
+		columns: _.union [
+			{
+				data: '_id'
+				title: 'Admin'
+				# TODO: use `tmpl`
+				createdCell: (node, cellData, rowData) ->
+					$(node).html(Blaze.toHTMLWithData Template.adminUsersIsAdmin, {_id: cellData}, node)
+				width: '40px'
+			}
+			{
+				data: 'emails'
+				title: 'Email'
+				render: (value) ->
+					value[0].address
+				searchable: true
+			}
+			{
+				data: 'emails'
+				title: 'Mail'
+				# TODO: use `tmpl`
+				createdCell: (node, cellData, rowData) ->
+					$(node).html(Blaze.toHTMLWithData Template.adminUsersMailBtn, {emails: cellData}, node)
+				width: '40px'
+			}
+			{ data: 'createdAt', title: 'Joined' }
+		], adminEditDelButtons
+		dom: adminTablesDom


### PR DESCRIPTION
allows for complete override of Users columns, etc. in the config

```
Users = Meteor.users;
AdminConfig = {
	collections: {
		Users: {
			...
		}
	}
}
```