### PR TITLE
Allow custom route options

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,53 @@ The `/admin/Posts/new` and `/admin/Posts/edit` will not use the `postWYSIGEditor
 
 Custom templates are most used when you need to use an {{#autoForm}} instead of the default {{> quickForm}}.
 
+#### Custom route options ####
+It is possible to setup some custom options that will be used during the
+generation of the routes for your collections. If no options are given, default
+ones will be used.
+
+This could be useful in order to set up `waitOn` or `onAfterAction` hooks:
+
+```javascript
+AdminConfig = {
+  // ...
+  collections: {
+    Posts: {
+      routes: {
+        new: {
+          waitOn: function () { return Meteor.subscribe('images'); }
+        },
+        view: {
+          waitOn: function () { return Meteor.subscribe('images'); }
+        },
+        edit: {
+          waitOn: function () { return Meteor.subscribe('images'); }
+        }
+      }
+    }
+  }
+  // ...
+}
+```
+
+All the options that Iron Router accept are also accepted here, except:
+`path`, `template`, `controller`, `action` and `data`.
+
+However, `data` context could be set up using the `collectionObject` key:
+```javascript
+AdminConfig = {
+  // ...
+  collections: {
+    Posts: {
+      collectionObject: {
+        key: 'value'
+      }
+    }
+  }
+  // ...
+}
+```
+
 #### Autoform ####
 ```javascript
 AdminConfig = {

--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -114,20 +114,30 @@ adminCreateRoutes = (collections) ->
 
 adminCreateRouteView = (collection, collectionName) ->
 	Router.route "adminDashboard#{collectionName}View",
+		adminCreateRouteViewOptions collection, collectionName
+
+adminCreateRouteViewOptions = (collection, collectionName) ->
+	options =
 		path: "/admin/#{collectionName}"
 		template: "AdminDashboardViewWrapper"
 		controller: "AdminController"
 		data: ->
-	  		admin_table: AdminTables[collectionName]
+  		admin_table: AdminTables[collectionName]
 		action: ->
 			@render()
 		onAfterAction: ->
 			Session.set 'admin_title', collectionName
 			Session.set 'admin_subtitle', 'View'
 			Session.set 'admin_collection_name', collectionName
+			collection.routes?.view?.onAfterAction
+	_.defaults options, collection.routes?.view
 
 adminCreateRouteNew = (collection, collectionName) ->
 	Router.route "adminDashboard#{collectionName}New",
+		adminCreateRouteNewOptions collection, collectionName
+
+adminCreateRouteNewOptions = (collection, collectionName) ->
+	options =
 		path: "/admin/#{collectionName}/new"
 		template: "AdminDashboardNew"
 		controller: "AdminController"
@@ -138,16 +148,23 @@ adminCreateRouteNew = (collection, collectionName) ->
 			Session.set 'admin_subtitle', 'Create new'
 			Session.set 'admin_collection_page', 'new'
 			Session.set 'admin_collection_name', collectionName
+			collection.routes?.new?.onAfterAction
 		data: ->
 			admin_collection: adminCollectionObject collectionName
+	_.defaults options, collection.routes?.new
 
 adminCreateRouteEdit = (collection, collectionName) ->
 	Router.route "adminDashboard#{collectionName}Edit",
+		adminCreateRouteEditOptions collection, collectionName
+
+adminCreateRouteEditOptions = (collection, collectionName) ->
+	options =
 		path: "/admin/#{collectionName}/:_id/edit"
 		template: "AdminDashboardEdit"
 		controller: "AdminController"
 		waitOn: ->
 			Meteor.subscribe 'adminCollectionDoc', collectionName, parseID(@params._id)
+			collection.routes?.edit?.waitOn
 		action: ->
 			@render()
 		onAfterAction: ->
@@ -157,8 +174,10 @@ adminCreateRouteEdit = (collection, collectionName) ->
 			Session.set 'admin_collection_name', collectionName
 			Session.set 'admin_id', parseID(@params._id)
 			Session.set 'admin_doc', adminCollectionObject(collectionName).findOne _id : parseID(@params._id)
+			collection.routes?.edit?.onAfterAction
 		data: ->
 			admin_collection: adminCollectionObject collectionName
+	_.defaults options, collection.routes?.edit
 
 adminPublishTables = (collections) ->
 	_.each collections, (collection, name) ->


### PR DESCRIPTION
Hi @yogiben,

Recently I experienced troubles setting up custom options for the routes generated by meteor-admin. Concretely about the waitOn hook to subscribe to other collections.

I hope this feature could be useful for someone. We could adapt my implementation to whatever you feel is right.

Here there is the documentation relating the feature:

#### Custom route options ####
It is possible to setup some custom options that will be used during the
generation of the routes for your collections. If no options are given, default
ones will be used.

This could be useful in order to set up `waitOn` or `onAfterAction` hooks:

```javascript
AdminConfig = {
  // ...
  collections: {
    Posts: {
      routes: {
        new: {
          waitOn: function () { return Meteor.subscribe('images'); }
        },
        view: {
          waitOn: function () { return Meteor.subscribe('images'); }
        },
        edit: {
          waitOn: function () { return Meteor.subscribe('images'); }
        }
      }
    }
  }
  // ...
}
```

All the options that Iron Router accept are also accepted here, except:
`path`, `template`, `controller`, `action` and `data`.

However, `data` context could be set up using the `collectionObject` key:
```javascript
AdminConfig = {
  // ...
  collections: {
    Posts: {
      collectionObject: {
        key: 'value'
      }
    }
  }
  // ...
}
```