### PR TITLE
'fixed' class removed on AdminLayout destroyed

### DIFF
--- a/lib/client/js/admin_layout.js
+++ b/lib/client/js/admin_layout.js
@@ -11,6 +11,10 @@ Template.AdminLayout.created = function () {
   $('body').addClass('fixed');
 };
 
+Template.AdminLayout.destroyed = function () {
+  $('body').removeClass('fixed');
+};
+
 Template.AdminLayout.helpers({
   minHeight: function () {
     return Template.instance().minHeight.get() + 'px'


### PR DESCRIPTION
The `fixed` class added to the body is sticky right now, and is never removed, messing with the styles of the rest of the app.