### PR TITLE
Make meteor-admin compatible with Meteor 1.2

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -6,7 +6,7 @@ adminEditButton = {
 	data: '_id'
 	title: 'Edit'
 	createdCell: (node, cellData, rowData) ->
-		$(node).html(Blaze.toHTMLWithData Template.adminEditBtn, {_id: cellData}, node)
+		$(node).html(Blaze.toHTMLWithData Template.adminEditBtn, {_id: cellData})
 	width: '40px'
 	orderable: false
 }
@@ -14,7 +14,7 @@ adminDelButton = {
 	data: '_id'
 	title: 'Delete'
 	createdCell: (node, cellData, rowData) ->
-		$(node).html(Blaze.toHTMLWithData Template.adminDeleteBtn, {_id: cellData}, node)
+		$(node).html(Blaze.toHTMLWithData Template.adminDeleteBtn, {_id: cellData})
 	width: '40px'
 	orderable: false
 }
@@ -185,7 +185,7 @@ Meteor.startup ->
 				title: 'Admin'
 				# TODO: use `tmpl`
 				createdCell: (node, cellData, rowData) ->
-					$(node).html(Blaze.toHTMLWithData Template.adminUsersIsAdmin, {_id: cellData}, node)
+					$(node).html(Blaze.toHTMLWithData Template.adminUsersIsAdmin, {_id: cellData})
 				width: '40px'
 			}
 			{
@@ -200,7 +200,7 @@ Meteor.startup ->
 				title: 'Mail'
 				# TODO: use `tmpl`
 				createdCell: (node, cellData, rowData) ->
-					$(node).html(Blaze.toHTMLWithData Template.adminUsersMailBtn, {emails: cellData}, node)
+					$(node).html(Blaze.toHTMLWithData Template.adminUsersMailBtn, {emails: cellData})
 				width: '40px'
 			}
 			{ data: 'createdAt', title: 'Joined' }

--- a/lib/client/html/admin_templates.html
+++ b/lib/client/html/admin_templates.html
@@ -148,7 +148,7 @@
 </template>
 
 <template name="adminUsersIsAdmin">
-	{{#if adminIsUserInRole _id 'admin'}}<i class="fa fa-check"></i>{{/if}}
+	{{#if adminIsUserInRole this._id 'admin'}}<i class="fa fa-check"></i>{{/if}}
 </template>
 
 <template name="adminUsersMailBtn">

--- a/lib/client/html/admin_templates.html
+++ b/lib/client/html/admin_templates.html
@@ -148,7 +148,7 @@
 </template>
 
 <template name="adminUsersIsAdmin">
-	{{#if adminIsUserInRole this._id 'admin'}}<i class="fa fa-check"></i>{{/if}}
+	{{#if adminIsUserInRole _id 'admin'}}<i class="fa fa-check"></i>{{/if}}
 </template>
 
 <template name="adminUsersMailBtn">


### PR DESCRIPTION
Removed cell node as parent node when rendering cell content.

Seems to fix #280 and #283 