### PR TITLE
waitOn improvements

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -122,8 +122,9 @@ adminCreateRouteEditOptions = (collection, collectionName) ->
 		template: "AdminDashboardEdit"
 		controller: "AdminController"
 		waitOn: ->
-			Meteor.subscribe 'adminCollectionDoc', collectionName, parseID(@params._id)
-			collection.routes?.edit?.waitOn
+			handle = Meteor.subscribe 'adminCollectionDoc', collectionName, parseID(@params._id)
+			handles = collection.routes?.edit?.waitOn?.apply(@, arguments) ? []
+			_.union([handle], handles)
 		action: ->
 			@render()
 		onAfterAction: ->


### PR DESCRIPTION
Passes context into waitOn so you can use `this.params`. Returns handles from custom waitOn so they are waited on before loading the view.