### PR TITLE
Meteor Factor's Website is at http, not https

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A complete admin dashboard solution for meteor built off the [iron-router](https
 
 ![alt tag](https://raw.githubusercontent.com/yogiben/meteor-admin/master/readme/screenshot2.png)
 
-Maintained by [Meteor Factory](https://meteorfactory.io). Professional Meteor development.
+Maintained by [Meteor Factory](http://meteorfactory.io). Professional Meteor development.
 
 [![Meteor admin](https://raw.githubusercontent.com/yogiben/meteor-admin/master/readme/meteor-factory.jpg)](http://meteorfactory.io)
 


### PR DESCRIPTION
See Issue [352](https://github.com/yogiben/meteor-admin/issues/352)

https goes to a dead page - like the site doesn't exist.

http works like a charm.

tested.