### PR TITLE
Fix #205 : Set default table sort

### DIFF
--- a/lib/both/startup.coffee
+++ b/lib/both/startup.coffee
@@ -65,6 +65,7 @@ adminCreateTables = (collections) ->
 			sub: collection.sub
 			columns: columns
 			extraFields: collection.extraFields
+			order: collection.order || []
 			dom: adminTablesDom
 			selector: collection.selector || ->
 				return {}


### PR DESCRIPTION
Tabular supports default column(s) sorting, I've just added a line to pass on the order option to Tabular. 
